### PR TITLE
Hybrid module (ESM and CommonJS)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
-node_modules
 .vscode
+cjs/*
+!cjs/.gitkeep
+node_modules

--- a/README.md
+++ b/README.md
@@ -12,11 +12,19 @@ The package is available to install via npm:
 npm i --save @cloudfour/simple-svg-placeholder
 ```
 
-Once installed, you may import and call the function to generate placeholder SVGs:
+Once installed, you may import the function as an ES or CommonJS module:
 
 ```javascript
-const simpleSvgPlaceholder = require('@cloudfour/simple-svg-placeholder');
+// Module
+import simpleSvgPlaceholder from 'simple-svg-placeholder';
 
+// CommonJS
+const simpleSvgPlaceholder = require('@cloudfour/simple-svg-placeholder');
+```
+
+Then call the function to generate placeholder SVGs:
+
+```javascript
 const placeholder = simpleSvgPlaceholder(/* options */);
 // => 'data:image/svg+xml;...'
 ```
@@ -28,7 +36,7 @@ const placeholder = simpleSvgPlaceholder(/* options */);
 ![](./examples/default.svg?sanitize=true)
 
 ```javascript
-simpleSvgPlaceholder()
+simpleSvgPlaceholder();
 ```
 
 ### Dimensions
@@ -38,8 +46,8 @@ simpleSvgPlaceholder()
 ```javascript
 simpleSvgPlaceholder({
   width: 180,
-  height: 135 
-})
+  height: 135,
+});
 ```
 
 ### Text
@@ -48,8 +56,8 @@ simpleSvgPlaceholder({
 
 ```javascript
 simpleSvgPlaceholder({
-  text: 'Hello world!' 
-})
+  text: 'Hello world!',
+});
 ```
 
 ### Colors
@@ -59,8 +67,8 @@ simpleSvgPlaceholder({
 ```javascript
 simpleSvgPlaceholder({
   bgColor: '#0F1C3F',
-  textColor: '#7FDBFF'
-})
+  textColor: '#7FDBFF',
+});
 ```
 
 ### Font
@@ -70,8 +78,8 @@ simpleSvgPlaceholder({
 ```javascript
 simpleSvgPlaceholder({
   fontFamily: 'Georgia, serif',
-  fontWeight: 'normal'
-})
+  fontWeight: 'normal',
+});
 ```
 
 ## Option Reference

--- a/examples/index.js
+++ b/examples/index.js
@@ -1,7 +1,7 @@
 import { writeFileSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
-// eslint-disable-next-line @cloudfour/node/no-unpublished-import
+// eslint-disable-next-line @cloudfour/n/no-unpublished-import
 import simpleSvgPlaceholder from '../mjs/index.js';
 
 const settings = { dataUri: false };

--- a/examples/index.js
+++ b/examples/index.js
@@ -1,8 +1,6 @@
-import { writeFileSync } from 'fs';
-import { join, dirname } from 'path';
-import { fileURLToPath } from 'url';
-// eslint-disable-next-line @cloudfour/n/no-unpublished-import
-import simpleSvgPlaceholder from '../mjs/index.js';
+const fs = require('fs');
+const path = require('path');
+const simpleSvgPlaceholder = require('..');
 
 const settings = { dataUri: false };
 
@@ -22,8 +20,10 @@ const examples = {
   }),
 };
 
-const dir = dirname(fileURLToPath(import.meta.url));
-
 for (const name of Object.keys(examples)) {
-  writeFileSync(join(dir, `./${name}.svg`), examples[name], 'utf8');
+  fs.writeFileSync(
+    path.join(__dirname, `./${name}.svg`),
+    examples[name],
+    'utf8'
+  );
 }

--- a/examples/index.js
+++ b/examples/index.js
@@ -1,6 +1,8 @@
-const fs = require('fs');
-const path = require('path');
-const simpleSvgPlaceholder = require('..');
+import { writeFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+// eslint-disable-next-line @cloudfour/node/no-unpublished-import
+import simpleSvgPlaceholder from '../mjs/index.js';
 
 const settings = { dataUri: false };
 
@@ -20,10 +22,8 @@ const examples = {
   }),
 };
 
+const dir = dirname(fileURLToPath(import.meta.url));
+
 for (const name of Object.keys(examples)) {
-  fs.writeFileSync(
-    path.join(__dirname, `./${name}.svg`),
-    examples[name],
-    'utf8'
-  );
+  writeFileSync(join(dir, `./${name}.svg`), examples[name], 'utf8');
 }

--- a/examples/package.json
+++ b/examples/package.json
@@ -1,3 +1,0 @@
-{
-  "type": "module"
-}

--- a/examples/package.json
+++ b/examples/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/mjs/index.js
+++ b/mjs/index.js
@@ -1,4 +1,4 @@
-function simpleSvgPlaceholder({
+export default function simpleSvgPlaceholder({
   width = 300,
   height = 150,
   text = `${width}×${height}`,
@@ -32,5 +32,3 @@ function simpleSvgPlaceholder({
 
   return cleaned;
 }
-
-module.exports = simpleSvgPlaceholder;

--- a/mjs/package.json
+++ b/mjs/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "@cloudfour/eslint-plugin": "21.1.0",
+        "ascjs": "^5.0.1",
         "eslint": "8.23.1",
         "prettier": "2.7.1",
         "typescript": "4.8.3"
@@ -873,6 +874,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/ascjs": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ascjs/-/ascjs-5.0.1.tgz",
+      "integrity": "sha512-1d/QdICzpywXiP53/Zz3fMdaC0/BB1ybLf+fK+QrqY8iyXNnWUHUrpmrowueXeswo+O+meJWm43TJSg2ClP3Sg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.12.5"
+      },
+      "bin": {
+        "ascjs": "bin.js"
       }
     },
     "node_modules/balanced-match": {
@@ -4271,6 +4284,15 @@
         "define-properties": "^1.1.3",
         "es-abstract": "^1.19.2",
         "es-shim-unscopables": "^1.0.0"
+      }
+    },
+    "ascjs": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ascjs/-/ascjs-5.0.1.tgz",
+      "integrity": "sha512-1d/QdICzpywXiP53/Zz3fMdaC0/BB1ybLf+fK+QrqY8iyXNnWUHUrpmrowueXeswo+O+meJWm43TJSg2ClP3Sg==",
+      "dev": true,
+      "requires": {
+        "@babel/parser": "^7.12.5"
       }
     },
     "balanced-match": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     ".": {
       "import": "./mjs/index.js",
       "require": "./cjs/index.js"
-    }
+    },
+    "./package.json": "./package.json",
   },
   "scripts": {
     "check-lint": "prettier --check '**/*.js' && eslint '**/*.js'",

--- a/package.json
+++ b/package.json
@@ -11,10 +11,18 @@
     "mock",
     "URI"
   ],
-  "main": "index.js",
+  "main": "cjs/index.js",
+  "module": "mjs/index.js",
+  "exports": {
+    ".": {
+      "import": "./mjs/index.js",
+      "require": "./cjs/index.js"
+    }
+  },
   "scripts": {
     "check-lint": "prettier --check '**/*.js' && eslint '**/*.js'",
     "lint": "prettier --write '**/*.js' && eslint --fix '**/*.js'",
+    "prepare": "ascjs mjs cjs --no-default",
     "examples": "node examples"
   },
   "eslintConfig": {
@@ -38,6 +46,7 @@
   "homepage": "https://github.com/cloudfour/simple-svg-placeholder#readme",
   "devDependencies": {
     "@cloudfour/eslint-plugin": "21.1.0",
+    "ascjs": "^5.0.1",
     "eslint": "8.23.1",
     "prettier": "2.7.1",
     "typescript": "4.8.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudfour/simple-svg-placeholder",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "A very simple placeholder image generator with zero dependencies. Returns a data URI (or raw SVG source) as a string for use in templates.",
   "keywords": [
     "SVG",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "homepage": "https://github.com/cloudfour/simple-svg-placeholder#readme",
   "devDependencies": {
     "@cloudfour/eslint-plugin": "21.1.0",
-    "ascjs": "^5.0.1",
+    "ascjs": "5.0.1",
     "eslint": "8.23.1",
     "prettier": "2.7.1",
     "typescript": "4.8.3"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
       "import": "./mjs/index.js",
       "require": "./cjs/index.js"
     },
-    "./package.json": "./package.json",
+    "./package.json": "./package.json"
   },
   "scripts": {
     "check-lint": "prettier --check '**/*.js' && eslint '**/*.js'",


### PR DESCRIPTION
Inspired by #120 (thanks @jasiqli) and using [this article](https://www.sensedeep.com/blog/posts/2021/how-to-create-single-source-npm-module.html) as a starting point (thanks @gerardo-rodriguez), this updates the package to support importing as an ES module or requiring as a CommonJS module.

Specific changes made:

- Moved the main source file to an `mjs` directory with a `package.json` specifying a type of `module`.
- Updated the main source file to use `export default` instead of `module.exports`.
- Added a `prepare` script using `ascjs` to build a CommonJS version of the file to the `cjs` directory. This prevents us from having to manage two separate files in the source, and using `ascjs` keeps the complexity of the resulting file to a minimum. My understanding is that this will run prior to publication to npm, but I'd love if someone could verify that.
- Updated `package.json` to include both `main` and `module` paths as well as conditional exports (see afore-linked article).
- Bumped the version number and updated the README.