### PR TITLE
Escape XML-significant characters in interpolated values

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,3 +24,5 @@ jobs:
         run: npm ci
       - name: Run linter 👀
         run: npm run check-lint
+      - name: Run tests 🧪
+        run: npm test

--- a/README.md
+++ b/README.md
@@ -96,6 +96,10 @@ Defaults to `150`, the default height of SVG elements in most browsers.
 
 The text to display. Defaults to the image dimensions.
 
+This is treated as literal text, not markup: characters that are significant in
+XML (`&`, `<`, `>`, `"`) are escaped for you, so `'Tom & Jerry'` renders as
+written rather than producing an SVG the browser refuses to parse.
+
 ### fontFamily `{String}`
 
 The font to use for the text. For data URIs, this needs to be a system-installed font. Defaults to `'sans-serif'`.
@@ -122,7 +126,7 @@ The color of the text. For transparency, use an `rgba` or `hsla` color value. De
 
 ### dataUri `{Boolean}`
 
-If `true`, the function will return an encoded string for use as an `img` element's `src` value. If `false`, the function will return the unencoded SVG source. Defaults to `true`.
+If `true`, the function will return an encoded string for use as an `img` element's `src` value. If `false`, the function will return the unencoded SVG source, suitable for inlining into a document. Defaults to `true`.
 
 ### charset `{String}`
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -9,4 +9,12 @@ export default [
       'unicorn/expiring-todo-comments': 'off',
     },
   },
+  {
+    // Tests are never published, so they are free to use `node:test` even
+    // though the package itself supports older versions of Node.
+    files: ['test/**'],
+    rules: {
+      'n/no-unsupported-features/node-builtins': 'off',
+    },
+  },
 ];

--- a/mjs/index.js
+++ b/mjs/index.js
@@ -1,3 +1,15 @@
+// SVG is XML, which — unlike HTML — refuses to render a document containing a
+// bare `&`, `<`, or `>`. Every interpolated value has to be escaped or ordinary
+// text like `Tom & Jerry` produces an image that silently fails to parse. The
+// attributes below are all double-quoted, so `'` can be left as-is; that keeps
+// quoted font stacks such as `'Comic Sans MS', cursive` intact.
+const escapeXml = (value) =>
+  String(value)
+    .replaceAll('&', '&amp;') // Must come first, or later entities double-escape
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;');
+
 export default function simpleSvgPlaceholder({
   width = 300,
   height = 150,
@@ -11,21 +23,26 @@ export default function simpleSvgPlaceholder({
   dataUri = true,
   charset = 'UTF-8',
 } = {}) {
-  const str = `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">
-    <rect fill="${bgColor}" width="${width}" height="${height}"/>
-    <text fill="${textColor}" font-family="${fontFamily}" font-size="${fontSize}" dy="${dy}" font-weight="${fontWeight}" x="50%" y="50%" text-anchor="middle">${text}</text>
+  const w = escapeXml(width);
+  const h = escapeXml(height);
+
+  const str = `<svg xmlns="http://www.w3.org/2000/svg" width="${w}" height="${h}" viewBox="0 0 ${w} ${h}">
+    <rect fill="${escapeXml(bgColor)}" width="${w}" height="${h}"/>
+    <text fill="${escapeXml(textColor)}" font-family="${escapeXml(fontFamily)}" font-size="${escapeXml(fontSize)}" dy="${escapeXml(dy)}" font-weight="${escapeXml(fontWeight)}" x="50%" y="50%" text-anchor="middle">${escapeXml(text)}</text>
   </svg>`;
 
   // Thanks to: filamentgroup/directory-encoder
   const cleaned = str
     .replaceAll(/[\t\n\r]/gim, '') // Strip newlines and tabs
-    .replaceAll(/\s\s+/g, ' ') // Condense multiple spaces
-    .replaceAll(/'/gim, String.raw`\i`); // Normalize quotes
+    .replaceAll(/\s\s+/g, ' '); // Condense multiple spaces
 
   if (dataUri) {
     const encoded = encodeURIComponent(cleaned)
       .replaceAll('(', '%28') // Encode brackets
-      .replaceAll(')', '%29');
+      .replaceAll(')', '%29')
+      // Left alone by encodeURIComponent, but significant inside the CSS
+      // `url()` values these data URIs are commonly pasted into.
+      .replaceAll("'", '%27');
 
     return `data:image/svg+xml;charset=${charset},${encoded}`;
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudfour/simple-svg-placeholder",
-  "version": "1.2.0",
+  "version": "1.1.0",
   "description": "A very simple placeholder image generator with zero dependencies. Returns a data URI (or raw SVG source) as a string for use in templates.",
   "keywords": [
     "SVG",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudfour/simple-svg-placeholder",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "A very simple placeholder image generator with zero dependencies. Returns a data URI (or raw SVG source) as a string for use in templates.",
   "keywords": [
     "SVG",
@@ -24,7 +24,8 @@
     "check-lint": "prettier --list-different . && eslint .",
     "lint": "prettier --write . && eslint --fix .",
     "prepare": "ascjs mjs cjs --no-default",
-    "examples": "node examples"
+    "examples": "node examples",
+    "test": "node --test"
   },
   "prettier": {
     "singleQuote": true

--- a/test/index.test.mjs
+++ b/test/index.test.mjs
@@ -1,0 +1,100 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import simpleSvgPlaceholder from '../mjs/index.js';
+
+/**
+ * Pulls the content out of the generated `<text>` element.
+ *
+ * @param {string} svg Raw SVG source.
+ * @returns {string} The escaped text content.
+ */
+const textContent = (svg) => svg.match(/<text[^>]*>(.*)<\/text>/)[1];
+
+test('returns a data URI by default', () => {
+  assert.match(simpleSvgPlaceholder(), /^data:image\/svg\+xml;charset=UTF-8,/);
+});
+
+test('returns raw SVG source when dataUri is false', () => {
+  assert.match(simpleSvgPlaceholder({ dataUri: false }), /^<svg /);
+});
+
+test('labels the placeholder with its dimensions by default', () => {
+  const svg = simpleSvgPlaceholder({ width: 180, height: 135, dataUri: false });
+
+  assert.equal(textContent(svg), '180×135');
+});
+
+test('uses the charset option in the data URI prefix', () => {
+  assert.match(
+    simpleSvgPlaceholder({ charset: 'ISO-8859-1' }),
+    /^data:image\/svg\+xml;charset=ISO-8859-1,/,
+  );
+});
+
+test('escapes an ampersand in text so the SVG stays well-formed XML', () => {
+  const svg = simpleSvgPlaceholder({ text: 'Tom & Jerry', dataUri: false });
+
+  assert.equal(textContent(svg), 'Tom &amp; Jerry');
+});
+
+test('escapes angle brackets in text rather than emitting them as markup', () => {
+  const svg = simpleSvgPlaceholder({ text: '<b>5 < 10</b>', dataUri: false });
+
+  assert.equal(textContent(svg), '&lt;b&gt;5 &lt; 10&lt;/b&gt;');
+});
+
+test('escapes a double quote so it cannot terminate an attribute value', () => {
+  const svg = simpleSvgPlaceholder({
+    bgColor: '#ddd" data-injected="1',
+    dataUri: false,
+  });
+
+  assert.match(svg, /<rect fill="#ddd&quot; data-injected=&quot;1"/);
+});
+
+test('escapes an ampersand in the data URI output too', () => {
+  const svg = simpleSvgPlaceholder({ text: 'Tom & Jerry' });
+
+  assert.match(svg, /Tom%20%26amp%3B%20Jerry/);
+});
+
+test('does not double-escape an ampersand that begins an entity', () => {
+  const svg = simpleSvgPlaceholder({ text: '&lt;', dataUri: false });
+
+  assert.equal(textContent(svg), '&amp;lt;');
+});
+
+test('preserves an apostrophe in text', () => {
+  const svg = simpleSvgPlaceholder({ text: "Scott's photo", dataUri: false });
+
+  assert.equal(textContent(svg), "Scott's photo");
+});
+
+test('preserves quoted font names in a font stack', () => {
+  const svg = simpleSvgPlaceholder({
+    fontFamily: "'Comic Sans MS', cursive",
+    dataUri: false,
+  });
+
+  assert.match(svg, /font-family="'Comic Sans MS', cursive"/);
+});
+
+test('percent-encodes an apostrophe so the data URI survives CSS url()', () => {
+  const svg = simpleSvgPlaceholder({ text: "Scott's photo" });
+
+  assert.match(svg, /Scott%27s%20photo/);
+});
+
+test('percent-encodes the brackets in the default rgba text color', () => {
+  assert.match(simpleSvgPlaceholder(), /rgba%280%2C0%2C0%2C0.5%29/);
+});
+
+test('leaves no unescaped markup characters anywhere in the output', () => {
+  const svg = simpleSvgPlaceholder({
+    text: '</text><svg onmouseover="alert(1)"><rect/></svg><text>',
+    dataUri: false,
+  });
+
+  assert.equal(svg.match(/<(svg|rect|text|\/text|\/svg)\b/g).length, 5);
+});


### PR DESCRIPTION
## Overview

SVG is XML, and XML has no error recovery — a bare `&`, `<`, or `>` is a fatal well-formedness error, not something the parser shrugs off the way an HTML parser would. Because option values were interpolated into the template as-is, entirely ordinary input like `text: 'Tom & Jerry'` generated a document that browsers refuse to render. This affected both `dataUri` modes: percent-encoding only hides the character in transit, and it decodes back to invalid XML before the parser ever sees it. Every interpolated value now runs through an `escapeXml` helper.

While in there, this retires the `'` → `\i` replacement inherited from filamentgroup/directory-encoder. That transform was meant to survive CSS `url('…')` contexts, but `\i` resolves to the letter `i` in CSS, so it corrupted the character rather than preserving it — `Scott's photo` came out as `Scott\is photo`. Percent-encoding `'` as `%27` in the data URI branch is both correct in CSS and lossless, and the raw SVG branch has no CSS context to guard against in the first place.

Two things worth a reviewer's attention. First, apostrophes are deliberately *not* escaped: every attribute in the template is double-quoted, so leaving `'` alone is safe and keeps font stacks like `'Comic Sans MS', cursive` usable. Second, this is a behavior change for anyone who was passing markup through `text` (e.g. `<tspan>`), which now renders as literal text — that use was never documented, so it warrants a minor release rather than a major. No version bump is included here; the release will be cut separately once this merges. The repo had no test suite, so this adds one and wires it into CI, which previously ran only the linter.

## Screenshots

## Testing

- [x] Run `npm test` — the suite should pass.
- [x] Run `npm run examples`, then confirm `git status` reports no changes to the `examples/` directory. The existing examples contain no special characters, so their output should be byte-identical.
- [x] In a scratch file, generate a placeholder with an ampersand in the text and write it to disk:
      `node -e "require('fs').writeFileSync('amp.svg', require('.')({ text: 'Tom & Jerry', dataUri: false }))"`
- [x] Open `amp.svg` in a browser. You should see a grey placeholder reading **Tom & Jerry**. On `main` this same file renders as an XML parsing error page instead.
- [x] Generate one with an apostrophe: `node -e "require('fs').writeFileSync('apos.svg', require('.')({ text: \"Scott's photo\", dataUri: false }))"`
- [x] Open `apos.svg` in a browser. The text should read **Scott's photo**. On `main` it reads `Scott\is photo`.
- [x] Generate a data URI with an apostrophe and use it as a CSS background to confirm the quote does not break out of the `url()` value:
      `node -e "const u = require('.')({ text: \"Scott's photo\" }); require('fs').writeFileSync('bg.html', \`<div style=\"width:300px;height:150px;background:url('\${u}')\"></div>\`)"`
- [x] Open `bg.html` in a browser. The placeholder should display, reading **Scott's photo**.
- [x] Delete the scratch files.

---

Closes #278