### PR TITLE
Use setup-node's built-in npm cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,12 +14,8 @@ jobs:
         uses: actions/checkout@v7.0.1
       - name: Setup Node env 🏗
         uses: actions/setup-node@v7.0.0
-      - name: Cache node_modules 📦
-        uses: actions/cache@v6.1.0
         with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: ${{ runner.os }}-node-
+          cache: 'npm'
       - name: Install dependencies 👨🏻‍💻
         run: npm ci
       - name: Run linter 👀


### PR DESCRIPTION
## Overview

Replaces the hand-rolled `actions/cache` block in CI with `actions/setup-node`'s built-in `cache: 'npm'` input. Both cache the same `~/.npm` directory; the difference is that `setup-node` generates the cache key itself, from the platform, architecture, and lockfile hash.

This is a consistency change rather than a performance one. The large majority of our repositories already use the built-in cache, and the block being removed is a copy-paste ancestor whose key omitted the runner architecture and matched `**/package-lock.json` instead of the root lockfile. Neither of those caused a problem in this repo, but keeping one pattern across our repositories makes the next round of CI maintenance cheaper.

## Screenshots

## Testing

- [ ] Open the Actions tab for this PR and confirm the CI workflow completes successfully
- [ ] In the CI job log, expand the **Use Node.js** step — it should report either restoring or saving an npm cache, replacing the separate cache step that used to appear
- [ ] Confirm there is no longer a **Cache node modules** step in the job