### PR TITLE
Extend shared Renovate preset

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -1,4 +1,4 @@
 {
-  "extends": ["config:recommended", ":automergeMinor", ":pinVersions"],
-  "minimumReleaseAge": "3 days"
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["local>cloudfour/renovate-config:library"]
 }


### PR DESCRIPTION
## Overview

This repo's `.renovaterc.json` was byte-identical to eleven other Cloud Four repos, which meant every Renovate config change we wanted everywhere had to be hand-applied across a dozen-plus files — something that's happened three or four times now. [`cloudfour/renovate-config`](https://github.com/cloudfour/renovate-config) is now the shared preset source, and this replaces the local config with a one-line `extends`.

This repo extends the `library` preset rather than the default because it publishes to npm. `library` is the default preset plus one rule that keeps `peerDependencies` and `engines` as ranges instead of pinning them. That rule is a no-op here today, since this package declares neither field — but the shared config pins exact versions globally, so the day someone adds an `engines` entry it would be silently pinned, forcing every downstream consumer onto that one exact version.

Otherwise behavior is unchanged: the same auto-merge and three-day cooldown rules still apply.

## Screenshots

## Testing

- [ ] Open `.renovaterc.json` on this branch — it should contain only a `$schema` line and a single `extends` entry pointing at `local>cloudfour/renovate-config:library`
- [ ] After merging, open the **Dependency Dashboard** issue in this repo and wait for Renovate to run (or tick the checkbox at the bottom of the dashboard to request an immediate run)
- [ ] The dashboard should render its usual list of pending updates with no error banner at the top. A red "Config Validation" or "Preset Not Found" warning would mean the preset failed to resolve
- [ ] Confirm behavior is unchanged: new patch and minor update PRs should still be set to auto-merge, and updates shouldn't appear until three days after the release

---

Part of cloudfour/renovate-config#1
