### PR TITLE
Pin the Node version in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
       - name: Setup Node env 🏗
         uses: actions/setup-node@v7.0.0
         with:
+          node-version: 'lts/*'
           cache: 'npm'
       - name: Install dependencies 👨🏻‍💻
         run: npm ci


### PR DESCRIPTION
## Overview

`actions/setup-node` was running with no `node-version`, so CI used whichever Node and npm happened to ship with the GitHub runner image. That version moves when GitHub updates the image, with no commit here, which means CI behaviour can change under us and local results can disagree with CI in ways that are hard to explain.

That's not hypothetical — it's what made #302 confusing. `npm ci` failed there with a lockfile error that could not be reproduced locally, because the runner's npm resolved an unsatisfied peer dependency (TypeScript, via `eslint-config-xo`) differently than the npm on our machines. Pinning the version doesn't fix that peer problem, but it does mean the next surprise of this shape is reproducible instead of environment-dependent.

I audited the rest of the org while I was here: of the 46 workflow files using `actions/setup-node`, this was the **only** one missing the field. The other 45 already pin it, so this brings us back in line rather than setting a new convention. `lts/*` is what our other repos use, and there's no `.nvmrc` here to read from instead.

## Screenshots

## Testing

- [ ] Open the Actions tab for this PR and click into the **CI** run
- [ ] Expand the **Setup Node env 🏗** step — it should log a resolved Node version rather than skipping straight to the cache setup
- [ ] Confirm the **Install dependencies 👨🏻‍💻**, **Run linter 👀** and **Run tests 🧪** steps behave the same as they do on `main` — this change should not alter any of them

---

Related to #302
